### PR TITLE
cerbot:v6 'requests' version requirement (use v2.31 for Python 3.7 & lower)

### DIFF
--- a/v6/requirements-base.txt
+++ b/v6/requirements-base.txt
@@ -1,2 +1,3 @@
 dirutility==0.7.20
-requests==2.31.0
+requests==2.31.0; python_version < "3.8"
+requests==2.32.3; python_version >= "3.8"


### PR DESCRIPTION
- fix 'requests' version constraint in v6 image requirements.txt