### PR TITLE
cerbot:v6 'urllib3' version constraint for Python 3.7

### DIFF
--- a/v6/requirements.txt
+++ b/v6/requirements.txt
@@ -27,7 +27,8 @@ pytz==2024.1
 requests-toolbelt==1.0.0
 six>=1.16.0
 tqdm==4.66.4
-urllib3==1.26.18
+urllib3==1.26.18; python_version < "3.8"
+urllib3==2.2.1; python_version >= "3.8"
 zope.component==6.0
 zope.deferredimport==5.0
 zope.deprecation==5.0


### PR DESCRIPTION
- fix urllib3 version constraint for Python 3.7 & lower