### PR TITLE
Cerbot v14 validation server request body params

### DIFF
--- a/v14/scripts/certbot.py
+++ b/v14/scripts/certbot.py
@@ -63,10 +63,11 @@ def main():
 
     # Send request to validation server
     for domain in args['domains']:
+        print('Domain: {0}'.format(domain))
         print('### Sending cert request for domain {} to the validation server...'.format(domain))
-        response = get('http://' + args['validation_domain'] + '/cert', data={'domain': domain,
-                                                                              'email': args['email'],
-                                                                              'staging': args['staging']})
+        response = get('http://' + args['validation_domain'] + '/cert', params={'domain': domain,
+                                                                                'email': args['email'],
+                                                                                'staging': args['staging']})
         print('\n' + response.text)
         print('### Received response to cert request for domain {} from the validation server...'.format(domain))
 


### PR DESCRIPTION
- fix get request made to validation server
- was previously passing 'data' when it should have been passing 'params'